### PR TITLE
Upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   "main": "index.js",
   "dependencies": {
     "plugin-error": "^1.0.1",
-    "po2json": "^0.4.5",
-    "through2": "^2.0.3"
+    "po2json": "1.0.0-alpha",
+    "through2": "^3.0.0"
   },
   "devDependencies": {
     "chai": "^4.1.2",


### PR DESCRIPTION
* Upgrading po2json is necessary along with the upgrade of Jed format.
* Since Node.js v0.10 and v0.12 are no longer in use, I think that you can upgrade through2 to v3.